### PR TITLE
ENV support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 **/node_modules/
 build/
+env/*
+!.gitkeep

--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ To run a test locally,
 
 `node scripts/main.js <YOUR-CANARY>`
 
+If you will use ENVIRONMENT_VARIABLES, write env and run it as follows,
+
+`node -r dotenv/config scripts/main.js <YOUR-CANARY> dotenv_config_path=env/<YOUR-CANARY>.env`
+
+```.env
+ENV_NAME_A=ENV_VALUE_A
+ENV_NAME_A=ENV_VALUE_B
+```
+
 ## Create zip
 
 For each canary, we can create a zip archive containing the dependencies.

--- a/package.json
+++ b/package.json
@@ -6,16 +6,17 @@
   "author": "",
   "license": "ISC",
   "scripts": {
-    "clean" : "rimraf build"
+    "clean": "rimraf build"
   },
   "devDependencies": {
     "archiver": "^5.3.0",
+    "dotenv": "^16.0.0",
     "install-local": "^3.0.1",
     "puppeteer": "^5.5.0",
     "rimraf": "^3.0.2"
   },
-  "workspaces" : [
-    "canaries/*", 
+  "workspaces": [
+    "canaries/*",
     "modules/*"
   ]
 }

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,14 +1,8 @@
-
 if (process.argv.length < 3) {
     console.error("argv must contains canary name");
     process.exit(1);
 }
 const canary = process.argv[2];
-
-// When you want to set env.
-// if (canary == "TARGET_CANARY") {
-//   process.env.YOUR_ENV_NAME = "YOUR_ENV_VALUE";
-// }
 
 (async () => {
     const synthetics = require('Synthetics');


### PR DESCRIPTION
Install dotenv as devDependencies. 
And env dir is prepared.
.gitignore contains env dir, it avoid to commit file that contains credentials